### PR TITLE
Date ranges

### DIFF
--- a/src/transforms/activity-calendar.js
+++ b/src/transforms/activity-calendar.js
@@ -1,7 +1,5 @@
-import dateFormat from "date-fns/format";
 import { RAW_KEYS } from "../constants";
-
-const format = (d, pattern = "yyyy-MM-dd") => dateFormat(d, pattern);
+import { format } from "../utils/date-format";
 
 export default function transform({ data }) {
   const entries = data.reduce((all, entry) => {

--- a/src/utils/date-format.js
+++ b/src/utils/date-format.js
@@ -1,0 +1,3 @@
+import dateFormat from "date-fns/format";
+
+export const format = (d, pattern = "yyyy-MM-dd") => dateFormat(d, pattern);

--- a/src/utils/date-range.js
+++ b/src/utils/date-range.js
@@ -1,3 +1,6 @@
+import subDays from "date-fns/subDays";
+import { format } from "./date-format";
+
 export const RANGE_TYPES = {
   thirtyDays: 30,
   sixtyDays: 60,
@@ -17,4 +20,12 @@ export function getRangeEnd({ start, type }) {
 
 export function isInRange({ start, end }, test) {
   return start <= test && test <= end;
+}
+
+export function subtractDays(from, count) {
+  return format(subDays(new Date(from), count));
+}
+
+export function getMinimumDate(dates) {
+  return dates.reduce((min, cur) => (cur < min ? cur : min));
 }

--- a/src/utils/date-range.js
+++ b/src/utils/date-range.js
@@ -1,0 +1,20 @@
+export const RANGE_TYPES = {
+  thirtyDays: 30,
+  sixtyDays: 60,
+  ninetyDays: 90,
+  oneYear: 365,
+  allTime: -1,
+};
+
+export function getRangeEnd({ start, type }) {
+  const end = "after start i imagine";
+  return {
+    start,
+    end,
+    type,
+  };
+}
+
+export function isInRange({ start, end }, test) {
+  return start <= test && test <= end;
+}

--- a/src/utils/date-range.test.js
+++ b/src/utils/date-range.test.js
@@ -1,0 +1,27 @@
+import { getRangeEnd, isInRange } from "./date-range";
+
+describe("isInRange()", () => {
+  const hindsight = { start: "2020-01-01", end: "2020-12-31" };
+
+  test("inclusive at the start of the range", async () => {
+    expect(isInRange(hindsight, hindsight.start)).toBe(true);
+  });
+  test("inclusive at the end of the range", async () => {
+    expect(isInRange(hindsight, hindsight.end)).toBe(true);
+  });
+  test("some rando in between", async () => {
+    expect(isInRange(hindsight, "2020-08-30")).toBe(true);
+  });
+
+  test("does not include day before range start", async () => {
+    expect(isInRange(hindsight, "2019-12-31")).toBe(false);
+    // fake day immediately before start of year too
+    expect(isInRange(hindsight, "2020-01-00")).toBe(false);
+  });
+  test("does not include day after range end", async () => {
+    // first day of 2021
+    expect(isInRange(hindsight, "2021-01-01")).toBe(false);
+    // fake date immediately afer range
+    expect(isInRange(hindsight, "2021-12-32")).toBe(false);
+  });
+});

--- a/src/utils/date-range.test.js
+++ b/src/utils/date-range.test.js
@@ -1,4 +1,4 @@
-import { getRangeEnd, isInRange } from "./date-range";
+import { getMinimumDate, isInRange, subtractDays } from "./date-range";
 
 describe("isInRange()", () => {
   const hindsight = { start: "2020-01-01", end: "2020-12-31" };
@@ -25,3 +25,33 @@ describe("isInRange()", () => {
     expect(isInRange(hindsight, "2021-12-32")).toBe(false);
   });
 });
+
+describe("subtractDays()", () => {
+  test("subtracts days innit", async () => {
+    expect(subtractDays("2020-01-31", 10)).toBe("2020-01-21");
+    expect(subtractDays("2020-01-31", 30)).toBe("2020-01-01");
+    expect(subtractDays("2020-01-31", 365)).toBe("2019-01-31");
+  });
+});
+
+describe("subtractDays()", () => {
+  test("subtracts days innit", async () => {
+    expect(subtractDays("2020-01-31", 10)).toBe("2020-01-21");
+  });
+});
+
+describe("getMinimumDate()", () => {
+  test("finds minimum in arrayy", async () => {
+    expect(
+      getMinimumDate(["2020-01-31", "2020-01-30", "2020-02-28", "2020-03-31"])
+    ).toBe("2020-01-30");
+  });
+});
+
+// from an array of 'dates' (probs via object.keys), an 'end' date, and a 'range'
+// e.g. dates = ["2020-01-31", "2020-01-30", "2020-02-28", "2020-03-31"] & end = "2020-09-10" & range = RANGE_TYPES.ninetyDays
+// getMinimumDate() in dates (historyStart: "2020-01-30")
+// if range is 'all', use the earliest date in `dates` (rangeStart: historyStart)
+// else 'rangeStart' = subtractDays('end', 'range')
+// next, getMinimumDate(['historyStart', 'rangeStart']) then keep the one that _isn't_ the minimum (the max) as 'start'
+// now, with the 'start' and 'end' of the range calculated, `filter()` the `dates` by `isInRange`

--- a/src/utils/decimal-rounding.js
+++ b/src/utils/decimal-rounding.js
@@ -1,3 +1,4 @@
+// TODO: ...mutiply by 10 instead
 const PLACES = [1, 10, 100, 1000, 10000, 100000, 1000000];
 export const toDecimalPlaces = (val, places = 0) =>
   Math.floor(val * PLACES[places]) / PLACES[places];


### PR DESCRIPTION
- from an array of 'dates' (probs via object.keys), an 'end' date, and a 'range'
- e.g. dates = ["2020-01-31", "2020-01-30", "2020-02-28"] & end = "2020-09-10" & range = RANGE_TYPES.ninetyDays
- getMinimumDate() in dates (historyStart: "2020-01-30")
- if range is 'all', use the earliest date in `dates` (rangeStart: historyStart)
- else 'rangeStart' = subtractDays('end', 'range')
- next, getMinimumDate(['historyStart', 'rangeStart']) then keep the one that _isn't_ the minimum (the max) as 'start'
- now, with the 'start' and 'end' of the range calculated, `filter()` the `dates` by `isInRange`