### PR TITLE
Automatically link between app views

### DIFF
--- a/src/pages/activity.jsx
+++ b/src/pages/activity.jsx
@@ -24,10 +24,6 @@ export const meta = {
   sidebar: "Annual Activity",
   component: Page,
   protected: true,
-  pagination: {
-    previous: "/totals",
-    next: "/instructors",
-  },
 };
 
 export function Page({ allWorkoutData, pageMetadata }) {

--- a/src/pages/average-metrics.jsx
+++ b/src/pages/average-metrics.jsx
@@ -14,10 +14,6 @@ export const meta = {
   sidebar: "Average Metrics",
   component: Page,
   protected: true,
-  pagination: {
-    previous: "/outputs",
-    next: null,
-  },
 };
 
 const OPTIONS = [AverageResistance, AverageCadenceRPM, AverageWatts, "All"];

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -7,15 +7,13 @@ import { meta as averageMetrics } from "./14-average-metrics";
 import { meta as styleguide } from "./100-styleguide";
 import { meta as styleguideButtons } from "./101-styleguide-buttons";
 
+const appViews = [totals, activity, instructors, outputs, averageMetrics];
+
 export default {
   // anyone
   [welcome.route]: welcome,
   // protected
-  [totals.route]: totals,
-  [activity.route]: activity,
-  [instructors.route]: instructors,
-  [outputs.route]: outputs,
-  [averageMetrics.route]: averageMetrics,
+  ...appViews.reduce((obj, view, idx) => ({ ...obj, [view.route]: view }), {}),
   // supporting pages
   [styleguide.route]: styleguide,
   [styleguideButtons.route]: styleguideButtons,

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,11 +1,11 @@
-import { meta as welcome } from "./00-welcome";
-import { meta as totals } from "./10-totals";
-import { meta as activity } from "./11-activity";
-import { meta as instructors } from "./12-instructors";
-import { meta as outputs } from "./13-outputs";
-import { meta as averageMetrics } from "./14-average-metrics";
-import { meta as styleguide } from "./100-styleguide";
-import { meta as styleguideButtons } from "./101-styleguide-buttons";
+import { meta as welcome } from "./welcome";
+import { meta as totals } from "./totals";
+import { meta as activity } from "./activity";
+import { meta as instructors } from "./instructors";
+import { meta as outputs } from "./outputs";
+import { meta as averageMetrics } from "./average-metrics";
+import { meta as styleguide } from "./styleguide";
+import { meta as styleguideButtons } from "./styleguide-buttons";
 
 const appViews = [totals, activity, instructors, outputs, averageMetrics];
 
@@ -13,7 +13,21 @@ export default {
   // anyone
   [welcome.route]: welcome,
   // protected
-  ...appViews.reduce((obj, view, idx) => ({ ...obj, [view.route]: view }), {}),
+  ...appViews.reduce(
+    (obj, view, idx) => ({
+      ...obj,
+      [view.route]: {
+        ...view,
+        pagination: {
+          // previous app view or back home
+          previous: appViews[idx - 1] ? appViews[idx - 1].route : "/",
+          // next app view or null (to disable next button). Later, share page
+          next: appViews[idx + 1] ? appViews[idx + 1].route : null,
+        },
+      },
+    }),
+    {}
+  ),
   // supporting pages
   [styleguide.route]: styleguide,
   [styleguideButtons.route]: styleguideButtons,

--- a/src/pages/index.test.js
+++ b/src/pages/index.test.js
@@ -8,9 +8,11 @@ describe("Page data config", () => {
       expect(typeof meta.title).toEqual("string");
       expect(typeof meta.component).toEqual("function");
       expect(typeof meta.protected).toEqual("boolean");
-      expect(typeof meta.pagination).toEqual("object");
-      expect(typeof meta.pagination.previous).toBeDefined();
-      expect(typeof meta.pagination.next).toBeDefined();
+      if (meta.pagination) {
+        expect(typeof meta.pagination).toEqual("object");
+        expect(typeof meta.pagination.previous).toBeDefined();
+        expect(typeof meta.pagination.next).toBeDefined();
+      }
       expect(meta.sidebar).toBeDefined();
     }
   );
@@ -20,10 +22,6 @@ describe("Page data config", () => {
       Object {
         "/": Object {
           "component": [Function],
-          "pagination": Object {
-            "next": null,
-            "previous": null,
-          },
           "protected": false,
           "route": "/",
           "sidebar": "Get Started",
@@ -75,10 +73,6 @@ describe("Page data config", () => {
         },
         "/styleguide": Object {
           "component": [Function],
-          "pagination": Object {
-            "next": null,
-            "previous": null,
-          },
           "protected": false,
           "route": "/styleguide",
           "sidebar": null,
@@ -86,10 +80,6 @@ describe("Page data config", () => {
         },
         "/styleguide/buttons": Object {
           "component": [Function],
-          "pagination": Object {
-            "next": null,
-            "previous": "/styleguide",
-          },
           "protected": false,
           "route": "/styleguide/buttons",
           "sidebar": null,

--- a/src/pages/instructors.jsx
+++ b/src/pages/instructors.jsx
@@ -11,10 +11,6 @@ export const meta = {
   sidebar: "Favorite Instructors",
   component: Page,
   protected: true,
-  pagination: {
-    previous: "/activity",
-    next: "/outputs",
-  },
 };
 
 export function Page({ allWorkoutData, pageMetadata }) {

--- a/src/pages/outputs.jsx
+++ b/src/pages/outputs.jsx
@@ -13,10 +13,6 @@ export const meta = {
   sidebar: "Cycling Outputs",
   component: Page,
   protected: true,
-  pagination: {
-    previous: "/instructors",
-    next: "/average-metrics",
-  },
 };
 
 export function Page({ allWorkoutData, pageMetadata }) {

--- a/src/pages/styleguide-buttons.jsx
+++ b/src/pages/styleguide-buttons.jsx
@@ -13,10 +13,6 @@ export const meta = {
   sidebar: null,
   component: Page,
   protected: false,
-  pagination: {
-    previous: "/styleguide",
-    next: null,
-  },
 };
 
 export function Page() {

--- a/src/pages/styleguide.jsx
+++ b/src/pages/styleguide.jsx
@@ -8,10 +8,6 @@ export const meta = {
   sidebar: null,
   component: Page,
   protected: false,
-  pagination: {
-    previous: null,
-    next: null,
-  },
 };
 
 export function Page() {

--- a/src/pages/totals.jsx
+++ b/src/pages/totals.jsx
@@ -12,10 +12,6 @@ export const meta = {
   sidebar: "Combined Totals",
   component: Page,
   protected: true,
-  pagination: {
-    previous: "/",
-    next: "/activity",
-  },
 };
 
 export function Page({ allWorkoutData, pageMetadata }) {

--- a/src/pages/welcome.jsx
+++ b/src/pages/welcome.jsx
@@ -9,10 +9,6 @@ export const meta = {
   sidebar: "Get Started",
   component: Page,
   protected: false,
-  pagination: {
-    previous: null,
-    next: null,
-  },
 };
 
 export default function Page() {


### PR DESCRIPTION
Instead of prev/next in the route's meta object, define the views in an array and grab that data from the neighbor. This allows for optional views based on user data relevancy.

- [x] Define views in array
- [x] Remove numbers from filenames
- [x] Remove pagination from view meta
- [x] Infer pagination from neighbor index
- [x] Update tests

fixes #69 